### PR TITLE
Enable dragging in non-portrait orientations

### DIFF
--- a/lib/DragContainer.js
+++ b/lib/DragContainer.js
@@ -11,10 +11,15 @@ import {
 
 global.Easing = Easing;
 
+const allOrientations = [
+  'portrait', 'portrait-upside-down',
+  'landscape', 'landscape-left', 'landscape-right'
+];
+
 class DragModal extends React.Component {
   render() {
     let {startPosition} = this.props.content;
-    return <Modal transparent={true}>
+    return <Modal transparent={true} supportedOrientations={allOrientations}>
         <TouchableWithoutFeedback onPressIn={this.props.drop}>
           <Animated.View style={this.props.location.getLayout()}>
             {this.props.content.children}


### PR DESCRIPTION
By default the `<Modal />` component is locked to portrait on iPhone-idiom devices.