### PR TITLE
Support Touchable Children

### DIFF
--- a/lib/Draggable.js
+++ b/lib/Draggable.js
@@ -28,13 +28,28 @@ class Draggable extends React.Component {
     }
 
     render() {
-        
+
         let isDragging = this.context.dragContext.dragging && this.context.dragContext.dragging.ref;
         isDragging = isDragging && isDragging === this.refs.wrapper;
-        return <TouchableOpacity activeOpacity={this.props.activeOpacity} style={this.props.style} onLongPress={this.props.dragOn === 'onLongPress' ? this._initiateDrag : null}  onPress={this.props.onPress} onPressIn={this.props.dragOn === 'onPressIn' ? this._initiateDrag : null} ref="wrapper">
+        const onLongPress = this.props.dragOn === 'onLongPress' ? this._initiateDrag : null
+        const onPressIn  = this.props.dragOn === 'onPressIn' ? this._initiateDrag : null
+        return <TouchableOpacity activeOpacity={this.props.activeOpacity} style={this.props.style} onLongPress={onLongPress}  onPress={this.props.onPress} onPressIn={onPressIn} ref="wrapper">
         {
           React.Children.map(this.props.children, child => {
-          return React.cloneElement(child, {ghost: isDragging})
+            let childClone = Object.assign({}, child) //unfreeze
+            let childType = childClone.type.displayName
+            const clickables =  [
+              "TouchableOpacity",
+              "TouchableHighlight",
+              "TouchableWithoutFeedback"
+            ]
+            if( clickables.indexOf(childType) > -1 ){ //if child has onLongPress and onPressIn props
+              childClone.props = Object.assign({}, childClone.props, { //give it the parent props
+                onLongPress,
+                onPressIn
+              })
+            }
+          return React.cloneElement(childClone, {ghost: isDragging})
         })
         }
       </TouchableOpacity>;


### PR DESCRIPTION
If we put a TouchableHighlight, TouchableOpacity or TouchableWithoutFeedback within the Draggable, it will not work because the onLongPress from children will override the draggable onLongPress/onPressIn

This commit solves this problem